### PR TITLE
Annotate patch-level outliers

### DIFF
--- a/analyze_vit_layerwise_boxplots.py
+++ b/analyze_vit_layerwise_boxplots.py
@@ -34,6 +34,7 @@ from pathlib import Path
 from typing import Dict, List
 
 import matplotlib.pyplot as plt
+from matplotlib.offsetbox import AnnotationBbox, OffsetImage
 import numpy as np
 import timm
 import torch
@@ -43,6 +44,8 @@ from PIL import Image
 BASE_DIR = Path.cwd()
 OUT_DIR = BASE_DIR / "viz" / "plots" / "act_analysis_vit_box"
 OUT_DIR.mkdir(parents=True, exist_ok=True)
+
+plt.style.use("seaborn-v0_8-whitegrid")
 
 DEVICE = "cuda:0"
 IMAGE_PATH = BASE_DIR / "test.png"
@@ -148,9 +151,20 @@ def analyse_model(model_id: str) -> Dict[str, List[float]]:
     image = Image.open(IMAGE_PATH).convert("RGB")
     pixel_values = transform(image).unsqueeze(0).to(DEVICE)
 
+    # Determine patch size from model if possible
+    patch_size = getattr(getattr(model, "patch_embed", None), "patch_size", 16)
+    if isinstance(patch_size, int):
+        patch_size = (patch_size, patch_size)
+    elif isinstance(patch_size, (list, tuple)):
+        patch_size = tuple(patch_size)
+    else:
+        patch_size = (16, 16)
+
+
     l2_mean, l2_std, raw_mean, raw_std = [], [], [], []
     p_l2_mean, p_l2_std, p_raw_mean, p_raw_std = [], [], [], []
-    layer_acts: List[np.ndarray] = []
+    layer_acts: List[np.ndarray] = []  # per-layer activations (num_tokens x hid)
+    layer_outliers: List[List[tuple]] = []  # (value, patch_idx)
 
     for b in blocks:
         l2s = [p.detach().float().norm(p=2).item() for p in b.parameters()]
@@ -168,7 +182,8 @@ def analyse_model(model_id: str) -> Dict[str, List[float]]:
         flat = h.flatten()
         raw_mean.append(flat.mean().item())
         raw_std.append(flat.std().item())
-        layer_acts.append(flat.cpu().numpy())
+        # store activations per token (num_tokens x hidden_size)
+        layer_acts.append(h.squeeze(0).cpu().numpy())
 
     # Register forward hooks on each block to capture the tensor returned by
     # ``forward``.  In ViT implementations from timm this output is the
@@ -184,6 +199,39 @@ def analyse_model(model_id: str) -> Dict[str, List[float]]:
     del model
     torch.cuda.empty_cache()
     gc.collect()
+
+    for arr in layer_acts:
+        mean = arr.mean()
+        std = arr.std()
+        mask = (arr > mean + 3 * std) | (arr < mean - 3 * std)
+        rows, cols = np.where(mask)
+        best: Dict[int, float] = {}
+        for r, c in zip(rows, cols):
+            val = float(arr[r, c])
+            if r not in best or abs(val) > abs(best[r]):
+                best[r] = val
+        layer_outliers.append([(v, r) for r, v in best.items()])
+
+    # Build small patch thumbnails aligned with token indices
+    num_tokens = layer_acts[0].shape[0] if layer_acts else 0
+    proc_h, proc_w = pixel_values.shape[2:]
+    grid_h, grid_w = proc_h // patch_size[0], proc_w // patch_size[1]
+    patch_tokens = grid_h * grid_w
+    extra_tokens = max(num_tokens - patch_tokens, 0)
+    resized = image.resize((proc_w, proc_h))
+    patch_thumbs = []
+    for i in range(grid_h):
+        for j in range(grid_w):
+            crop = resized.crop(
+                (
+                    j * patch_size[1],
+                    i * patch_size[0],
+                    (j + 1) * patch_size[1],
+                    (i + 1) * patch_size[0],
+                )
+            )
+            patch_thumbs.append(crop.resize((32, 32)))
+    patch_thumbs = [None] * extra_tokens + patch_thumbs
 
     safe = model_id.replace("/", "__")
     stats = {
@@ -216,10 +264,10 @@ def analyse_model(model_id: str) -> Dict[str, List[float]]:
         plt.close()
         print("    Plot ", p)
 
-    def _plot_box(data: List[np.ndarray]) -> None:
+    def _plot_box(data: List[np.ndarray], outliers: List[List[tuple]], thumbs: List[Image.Image]) -> None:
         if not data:
             return
-        plt.figure(figsize=(12, 0.5 * len(data) + 3), dpi=300)
+        fig, ax = plt.subplots(figsize=(12, 0.5 * len(data) + 3), dpi=300)
         plt.boxplot(
             data,
             vert=True,
@@ -227,21 +275,26 @@ def analyse_model(model_id: str) -> Dict[str, List[float]]:
             showfliers=True,
             flierprops={"marker": "o", "markersize": 2, "markerfacecolor": "r", "alpha": 0.6},
         )
-        plt.xlabel("Block")
-        plt.ylabel("Activation value")
-        plt.title(f"{model_id} activation distribution", weight="bold")
-        plt.grid(True, ls="--", lw=0.4, axis="y")
-        plt.tight_layout()
+        for i, outs in enumerate(outliers):
+            for val, idx in outs:
+                if idx < len(thumbs) and thumbs[idx] is not None:
+                    ab = AnnotationBbox(OffsetImage(thumbs[idx], zoom=0.5), (i + 1.05, val), frameon=False)
+                    ax.add_artist(ab)
+        ax.set_xlabel("Block")
+        ax.set_ylabel("Activation value")
+        ax.set_title(f"{model_id} activation distribution", weight="bold")
+        ax.grid(True, ls="--", lw=0.4, axis="y")
+        fig.tight_layout()
         p = OUT_DIR / f"{safe}_box.png"
-        plt.savefig(p)
-        plt.close()
+        fig.savefig(p)
+        plt.close(fig)
         print("    Plot ", p)
 
     _plot(l2_mean, l2_std, f"{model_id} ||act||_2", "L2 norm", "l2")
     _plot(raw_mean, raw_std, f"{model_id} raw act", "Activation", "raw")
     _plot(p_l2_mean, p_l2_std, f"{model_id} ||theta||_2", "Parameter L2 norm", "param_l2")
     _plot(p_raw_mean, p_raw_std, f"{model_id} raw theta", "Parameter value", "param_raw")
-    _plot_box(layer_acts)
+    _plot_box(layer_acts, layer_outliers, patch_thumbs)
     return stats
 
 


### PR DESCRIPTION
## Summary
- capture per-token activations for ViTs to record patch indices
- crop resized image into patches and attach thumbnails to outlier points
- update whisker plot helper to overlay patch thumbnails

## Testing
- `python -m py_compile analyze_layerwise_boxplots.py analyze_vit_layerwise_boxplots.py`
